### PR TITLE
Fix eyedropper tool (layer-agnostic sampling)

### DIFF
--- a/main.py
+++ b/main.py
@@ -488,8 +488,16 @@ class DrawingCanvas(tk.Canvas):
         return self.app.is_alt_eyedropper_active(event)
 
     def _sample_color(self, x, y, target):
-        layer = self.layer_manager.get_active_layer()
-        color = layer.get_pixel(x, y)
+        width = self.layer_manager.width
+        height = self.layer_manager.height
+        if not (0 <= x < width and 0 <= y < height):
+            return
+
+        # Sample from the composite of all visible layers so the eyedropper
+        # is layer-agnostic ("what you see is what you pick").
+        composite = self.layer_manager.render_composite()
+        idx = (y * width + x) * 4
+        color = composite[idx:idx + 4]
         if color[3] == 0:
             return
 


### PR DESCRIPTION
## Problem
The eyedropper tool was not working reliably. It sampled color only from the **active layer** (`get_active_layer().get_pixel()`), so it silently did nothing whenever the visible pixel lived on a different layer or the active layer was transparent at that point.

## Fix
Sample from `LayerManager.render_composite()` — the exact same composited data the canvas renders — so the eyedropper is layer-agnostic ("what you see is what you pick"). Also added a bounds check so clicks outside the canvas are ignored safely.

Works for both the dedicated eyedropper tool and the Alt-hold quick-pick, for foreground (left/click) and background (right-click).

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)