### PR TITLE
Make layer items fill the full panel width

### DIFF
--- a/main.py
+++ b/main.py
@@ -1333,11 +1333,15 @@ class App:
         self.layer_canvas.pack(fill=tk.X, expand=False)
 
         self.layer_inner = tk.Frame(self.layer_canvas, bg="#333333")
-        self.layer_canvas.create_window(
+        self.layer_window = self.layer_canvas.create_window(
             (0, 0), window=self.layer_inner, anchor=tk.NW)
 
         self.layer_inner.bind("<Configure>", lambda e: self.layer_canvas.configure(
             scrollregion=self.layer_canvas.bbox("all")))
+        # Stretch the inner frame to the canvas width so layer rows always fill
+        # the panel regardless of the longest layer name.
+        self.layer_canvas.bind("<Configure>", lambda e: self.layer_canvas.itemconfig(
+            self.layer_window, width=e.width))
 
         btn_frame = tk.Frame(layer_frame, bg=PANEL_COLOR)
         btn_frame.pack(fill=tk.X, pady=2)


### PR DESCRIPTION
Fixes #5

## Problem
The width of the layer items list was determined by the layer with the longest name. Layers with shorter names did not take up the full width of the layers panel.

## Fix
Bind the layer canvas `<Configure>` event to stretch the inner frame (the canvas window holding the layer rows) to the canvas width. Layer rows now always fill the full width of the panel regardless of layer name length.