### PR TITLE
Release v1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to SpriteLite are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project uses a simple `MAJOR.MINOR` versioning scheme.
+
+## [1.1] - 2026-06-16
+
+### Added
+
+- Frame-based animation: a timeline at the bottom of the canvas for adding and
+  managing frames, a play/stop control, an adjustable playback-speed selector
+  (10%–100%), and export to either a spritesheet or individual frame PNGs.
+  Existing single-frame projects are migrated automatically. (#6)
+- Copy and paste for the selection tool (`Ctrl+C` / `Ctrl+V`), with a small
+  offset on paste so a pasted copy doesn't perfectly cover the original. (#1)
+- Built-in palette selector that auto-detects palettes from a `palettes` folder
+  next to the app and ships with Endesga 32 (default), PICO-8, Paperback-2,
+  Miyazaki 16, AGB, and NaNoNES. (#10)
+- `Alt+Backspace` fills the active layer with the foreground color, or just the
+  selected region when a selection is active. (#2)
+
+### Changed
+
+- Undo/redo now covers layer operations (add, delete, reorder, rename,
+  visibility) and animation frame changes, not only canvas edits. (#3)
+- Layer items now fill the full width of the layers panel regardless of layer
+  name length. (#5)
+- The eyedropper tooltip now indicates that holding `Alt` toggles the tool for
+  rapid color picking. (#4)
+
+### Fixed
+
+- The eyedropper now samples the composited color across all visible layers
+  instead of failing or only reading the active layer. (#12)
+- SpriteLite now prompts to save unsaved changes before closing. (#11)
+
+## [1.0] - 2026-03-09
+
+- Initial release: Tkinter-based pixel editor with pencil, eraser, bucket fill,
+  eyedropper, and selection tools; layer-based editing; PNG import/export and
+  `.sprlite` project save/load; zoom, pan, grid, undo/redo, and palette loading.
+- Windows 64-bit, Windows 32-bit, and Linux builds.

--- a/main.py
+++ b/main.py
@@ -57,7 +57,7 @@ BASE_FRAME_DELAY_MS = 100
 # so a pasted copy doesn't perfectly cover the original and repeats cascade.
 PASTE_OFFSET = 1
 
-APP_VERSION = "1.0"
+APP_VERSION = "1.1"
 GITHUB_REPO_URL = "https://github.com/elevchyt/spritelite"
 APP_DEVELOPER = "Eleftherios Hytiroglou"
 


### PR DESCRIPTION
Prepares the **v1.1** release.

- Bumps `APP_VERSION` from `1.0` to `1.1`.
- Adds `CHANGELOG.md` documenting all changes since v1.0.

## Changes since v1.0

### Added
- Frame-based animation: timeline, play/stop, playback-speed selector, and export to spritesheet or individual frames (#6)
- Copy/paste for the selection tool (#1)
- Palette selector from a default `palettes` folder, with extra palettes out of the box (#10)
- `Alt+Backspace` fills the active layer (or active selection) with the foreground color (#2)

### Changed
- Undo/redo now covers layer and animation-frame changes, not just canvas edits (#3)
- Layer items fill the full panel width (#5)
- Eyedropper tooltip indicates the hold-`Alt` shortcut (#4)

### Fixed
- Eyedropper samples across all visible layers (#12)
- Prompt to save unsaved changes before closing (#11)
